### PR TITLE
Remove unnecessary __future__ imports

### DIFF
--- a/src/lxrt/file_utils.py
+++ b/src/lxrt/file_utils.py
@@ -3,7 +3,6 @@ Utilities for working with the local dataset cache.
 This file is adapted from the AllenNLP library at https://github.com/allenai/allennlp
 Copyright by the AllenNLP authors.
 """
-
 import json
 import logging
 import os

--- a/src/lxrt/file_utils.py
+++ b/src/lxrt/file_utils.py
@@ -3,7 +3,6 @@ Utilities for working with the local dataset cache.
 This file is adapted from the AllenNLP library at https://github.com/allenai/allennlp
 Copyright by the AllenNLP authors.
 """
-from __future__ import (absolute_import, division, print_function, unicode_literals)
 
 import json
 import logging

--- a/src/lxrt/modeling.py
+++ b/src/lxrt/modeling.py
@@ -16,8 +16,6 @@
 # limitations under the License.
 """PyTorch LXRT model."""
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import copy
 import json
 import logging

--- a/src/lxrt/tokenization.py
+++ b/src/lxrt/tokenization.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 """Tokenization classes."""
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import collections
 import logging
 import os

--- a/src/pretrain/lxmert_pretrain.py
+++ b/src/pretrain/lxmert_pretrain.py
@@ -1,8 +1,6 @@
 # coding=utf-8
 # Copyright 2019 project LXRT.
 
-from __future__ import absolute_import, division, print_function
-
 import collections
 import os
 import random


### PR DESCRIPTION
Because the codebase says it's for Python 3, these imports seem unnecessary.