### PR TITLE
Add the NLVR repo as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "data/nlvr2/nlvr"]
+	path = data/nlvr2/nlvr
+	url = https://github.com/lil-lab/nlvr.git

--- a/README.md
+++ b/README.md
@@ -219,9 +219,9 @@ https://evalai.cloudcv.org/web/challenges/challenge-page/225/leaderboard
 
 #### Fine-tuning
 
-- Download the NLVR2 data from the official [github repo](https://github.com/lil-lab/nlvr).
+- Download the NLVR2 data from the official [GitHub repo](https://github.com/lil-lab/nlvr).
 ```bash
-git clone https://github.com/lil-lab/nlvr.git data/nlvr2/nlvr
+git submodule update --init
 ```
 
 - Process the NLVR2 data to json files.


### PR DESCRIPTION
For reproducibility purposes, I think it's better to use the NLVR repo as a [git submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules). This allows pointing to a certain commit of their repo, and if they break compatibility with this codebase then this repo will still be fine.